### PR TITLE
Clarify licensing of the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,4 +76,4 @@ Contributions are welcome! Please open issues or pull requests for bug fixes, ne
 
 ## License
 
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+This project is licensed under the Apache License, Version 2.0. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
There is an ambiguity in which license is actually valid for this project: the README file refers to the MIT license, but LICENSE is the Apache License, Version 2.0.

This pull request sorts out this issue by changing the README file to say the license is Apache-2.0. I am assuming this is the license a company in DE will be more likely to select.

Please ensure this change goes through review by your legal experts/department or similar before merging this pull request.