### PR TITLE
fix: wait until all network connections finished before taking screen…

### DIFF
--- a/packages/paperlesspaper-api/src/render/render.service.ts
+++ b/packages/paperlesspaper-api/src/render/render.service.ts
@@ -140,7 +140,7 @@ const generateImageFromUrl = async ({
       deviceScaleFactor: 1,
     });
     //console.log('Navigating to URL:', urlLocal);
-    await page.goto(urlLocal, { waitUntil: "networkidle2", timeout: 5000 });
+    await page.goto(urlLocal, { waitUntil: "networkidle0", timeout: 5000 });
     //console.log('Page loaded:', urlLocal);
 
     await adBlock(page);


### PR DESCRIPTION
Fixes an issues with blank (black) screens.

With networkidle2, screenshot will be taken when max 2 network connections are still open. This can lead to blank screenshots e.g. if an image still needs to be loaded.

Consider 
<https://apps.paperlesspaper.de/apple-photos-random?token=B2HGI9HKKGi9Fdw>
This will render a black image with networkidle2, but correctly (random image from the album) with networkidle0

Similar, even simpler example
<https://ct-paperlesspaper.vercel.app/xkcd.html>
which loads an image via a redirect and results in a blank page with the current networkidle2 setting.

With networkidle0, the renderer waits until all network connections are finished before taking the screenshot. Since there is also a timeout given, there is no risk of infinite wait time e.g. if the site periodically polls.
